### PR TITLE
feat: Implement custom input widgets in MessageComposer

### DIFF
--- a/backend/chainlit/custom_widgets.py
+++ b/backend/chainlit/custom_widgets.py
@@ -1,0 +1,17 @@
+COMPOSER_WIDGETS_CONFIG = [
+    {
+        "name": "model_selection_dropdown",
+        "display": "inline",
+        "type": "custom",  # Added type as per instructions
+        "props": {
+            "widgetType": "dropdown",
+            "label": "Select Model",
+            "id": "model_dropdown_widget", # HTML ID for the element
+            "options": [
+                { "value": "gpt-4", "label": "GPT-4" },
+                { "value": "claude-2", "label": "Claude 2" },
+            ],
+            "initialValue": "gpt-4",
+        }
+    }
+]

--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -43,11 +43,16 @@ class MessageBase(ABC):
     language: Optional[str] = None
     metadata: Optional[Dict] = None
     tags: Optional[List[str]] = None
+    custom_widgets: Optional[Dict[str, Any]] = None # Added custom_widgets
     wait_for_answer = False
 
     def __post_init__(self) -> None:
         trace_event(f"init {self.__class__.__name__}")
         self.thread_id = context.session.thread_id
+
+        # Populate custom_widgets from metadata if metadata exists
+        if self.metadata and "custom_widgets" in self.metadata:
+            self.custom_widgets = self.metadata["custom_widgets"]
 
         previous_steps = local_steps.get() or []
         parent_step = previous_steps[-1] if previous_steps else None
@@ -60,7 +65,7 @@ class MessageBase(ABC):
     @classmethod
     def from_dict(self, _dict: StepDict):
         type = _dict.get("type", "assistant_message")
-        return Message(
+        instance = Message( # Changed to instance = Message(...)
             id=_dict["id"],
             parent_id=_dict.get("parentId"),
             created_at=_dict["createdAt"],
@@ -71,6 +76,10 @@ class MessageBase(ABC):
             language=_dict.get("language"),
             metadata=_dict.get("metadata", {}),
         )
+        # Populate custom_widgets from metadata after instance creation
+        if instance.metadata and "custom_widgets" in instance.metadata:
+            instance.custom_widgets = instance.metadata["custom_widgets"]
+        return instance
 
     def to_dict(self) -> StepDict:
         _dict: StepDict = {
@@ -261,6 +270,10 @@ class Message(MessageBase):
         self.elements = elements if elements is not None else []
 
         super().__post_init__()
+
+        # Also populate custom_widgets in __init__ for direct instantiations
+        if self.metadata and "custom_widgets" in self.metadata:
+            self.custom_widgets = self.metadata["custom_widgets"]
 
     async def send(self):
         """

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -13,6 +13,8 @@ from chainlit.auth import (
 )
 from chainlit.chat_context import chat_context
 from chainlit.config import config
+from chainlit.custom_widgets import COMPOSER_WIDGETS_CONFIG
+from chainlit.element import CustomElement
 from chainlit.context import init_ws_context
 from chainlit.data import get_data_layer
 from chainlit.logger import logger
@@ -193,6 +195,20 @@ async def connection_successful(sid):
             return
         else:
             await context.emitter.send_resume_thread_error("Thread not found.")
+
+    # Send custom input widgets
+    for widget_config in COMPOSER_WIDGETS_CONFIG:
+        element = CustomElement(
+            thread_id=context.session.thread_id,
+            name=widget_config["name"],
+            display=widget_config["display"],
+            props=widget_config["props"],
+            type=widget_config["type"], # Make sure type is passed
+        )
+        # The CustomElement class should ideally handle its own ID.
+        # If props["id"] is meant to be the HTML ID, it's correctly in props.
+        # element.id = widget_config["props"]["id"] # This would override the element's unique ID, which might not be intended.
+        await element.send(for_id="COMPOSER_WIDGET", persist=False)
 
     if config.code.on_chat_start:
         task = asyncio.create_task(config.code.on_chat_start())

--- a/backend/tests/test_custom_widgets.py
+++ b/backend/tests/test_custom_widgets.py
@@ -1,0 +1,54 @@
+import unittest
+from chainlit.custom_widgets import COMPOSER_WIDGETS_CONFIG
+
+class TestCustomWidgets(unittest.TestCase):
+    def test_composer_widgets_config_structure(self):
+        self.assertIsInstance(COMPOSER_WIDGETS_CONFIG, list, "COMPOSER_WIDGETS_CONFIG should be a list")
+        
+        if not COMPOSER_WIDGETS_CONFIG:
+            # If it's empty, it's technically valid but maybe not intended for production.
+            # For this test, we'll assume it can be empty or populated.
+            # If it must be non-empty, add self.assertTrue(COMPOSER_WIDGETS_CONFIG)
+            return
+
+        for widget_config in COMPOSER_WIDGETS_CONFIG:
+            self.assertIsInstance(widget_config, dict, "Each widget config should be a dictionary")
+            
+            self.assertIn("name", widget_config, "Widget config must have a 'name'")
+            self.assertIsInstance(widget_config["name"], str, "'name' must be a string")
+
+            self.assertIn("display", widget_config, "Widget config must have a 'display'")
+            self.assertIsInstance(widget_config["display"], str, "'display' must be a string") # Assuming 'inline', 'side', 'page' etc.
+
+            self.assertIn("type", widget_config, "Widget config must have a 'type'")
+            self.assertEqual(widget_config["type"], "custom", "'type' must be 'custom'")
+
+            self.assertIn("props", widget_config, "Widget config must have 'props'")
+            self.assertIsInstance(widget_config["props"], dict, "'props' must be a dictionary")
+
+            props = widget_config["props"]
+            self.assertIn("widgetType", props, "Props must have 'widgetType'")
+            self.assertIsInstance(props["widgetType"], str, "'widgetType' must be a string")
+            
+            self.assertIn("id", props, "Props must have 'id' (HTML ID)")
+            self.assertIsInstance(props["id"], str, "'id' must be a string")
+
+            # Example for dropdown, expand as more widget types are added
+            if props["widgetType"] == "dropdown":
+                self.assertIn("label", props, "Dropdown props must have 'label'")
+                self.assertIsInstance(props["label"], str, "Dropdown 'label' must be a string")
+                
+                self.assertIn("options", props, "Dropdown props must have 'options'")
+                self.assertIsInstance(props["options"], list, "Dropdown 'options' must be a list")
+                for option in props["options"]:
+                    self.assertIsInstance(option, dict, "Each dropdown option should be a dictionary")
+                    self.assertIn("value", option, "Dropdown option must have 'value'")
+                    self.assertIn("label", option, "Dropdown option must have 'label'")
+                
+                self.assertIn("initialValue", props, "Dropdown props must have 'initialValue'")
+                # initialValue can be various types, but often string for dropdowns
+                self.assertTrue(isinstance(props["initialValue"], (str, int, float, bool)), 
+                                "Dropdown 'initialValue' should be a basic type")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_message.py
+++ b/backend/tests/test_message.py
@@ -1,0 +1,111 @@
+import unittest
+from chainlit.message import Message, MessageBase # Adjust if MessageBase is not directly used or needed
+from chainlit.context import init_context # Required for context initialization
+from chainlit.session import WebsocketSession # Required for context
+from chainlit.user import User # Required for context
+from chainlit.config import init_config # Required for config init
+
+# Mocking necessary parts for Message instantiation if not testing full context
+class MockEmitter:
+    async def send_step(self, step_dict):
+        pass
+    async def update_step(self, step_dict):
+        pass
+    async def delete_step(self, step_id):
+        pass
+    # Add other methods if Message interaction requires them
+
+class MockWebsocketSession(WebsocketSession):
+    def __init__(self, id="test_session_id", thread_id="test_thread_id", emit_fn=None, call_fn=None, client_type=None, user_env=None, user=None, token=None, chat_profile=None, environ=None):
+        super().__init__(id, "test_socket_id", emit_fn or (lambda event, data: None), call_fn or (lambda event, data, timeout: None), client_type, user_env, user or User(identifier="test_user"), token, chat_profile, thread_id, environ)
+        self.emitter = MockEmitter()
+
+class TestMessageClass(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Initialize config (using default or test-specific config if available)
+        init_config(True) # Assuming True sets up a basic/test config
+
+    def setUp(self):
+        # Initialize context for each test if Message relies on it
+        # This is a simplified setup. If your Message class or its __post_init__
+        # needs a more complete context, you'll need to expand this.
+        session = MockWebsocketSession()
+        init_context(session=session)
+
+
+    def test_message_custom_widgets_population_on_init(self):
+        metadata_with_widgets = {
+            "custom_widgets": {"model_dropdown_widget": "gpt-4"},
+            "location": "test_location"
+        }
+        
+        # Test direct instantiation
+        # __post_init__ in MessageBase is expected to handle custom_widgets from metadata
+        msg = Message(content="Hello", author="User", metadata=metadata_with_widgets)
+
+        self.assertIsNotNone(msg.custom_widgets, "custom_widgets should be populated")
+        self.assertEqual(msg.custom_widgets.get("model_dropdown_widget"), "gpt-4", 
+                         "custom_widgets 'model_dropdown_widget' value is incorrect")
+
+        metadata_without_widgets = {"location": "test_location"}
+        msg_no_widgets = Message(content="Hi", author="User", metadata=metadata_without_widgets)
+        self.assertIsNone(msg_no_widgets.custom_widgets, 
+                          "custom_widgets should be None when not in metadata")
+        
+        msg_empty_metadata = Message(content="Hola", author="User", metadata={})
+        self.assertIsNone(msg_empty_metadata.custom_widgets,
+                            "custom_widgets should be None for empty metadata")
+
+        msg_none_metadata = Message(content="Bonjour", author="User", metadata=None)
+        self.assertIsNone(msg_none_metadata.custom_widgets,
+                            "custom_widgets should be None when metadata is None")
+
+
+    def test_message_custom_widgets_population_from_dict(self):
+        # This test relies on MessageBase.from_dict and how it handles metadata.
+        # The actual dict structure for from_dict might be more complex than this example.
+        # Adjust mock_payload based on the expected structure for StepDict.
+        
+        metadata_with_widgets = {
+            "custom_widgets": {"model_select": "claude-2", "temperature": 0.7},
+            "source": "from_dict_test"
+        }
+        mock_payload_with_widgets = {
+            "id": "test_msg_id_1",
+            "threadId": "test_thread_id_1", # threadId is used by __post_init__
+            "parentId": None, # Optional
+            "createdAt": "2023-01-01T12:00:00Z", # Example string
+            "output": "Test message from dict", # Maps to content
+            "name": "TestAuthor", # Maps to author
+            "type": "user_message", # Or any valid MessageStepType
+            "metadata": metadata_with_widgets,
+            # Other fields like command, language, streaming, isError, waitForAnswer, tags
+            # might be needed if from_dict or __init__ uses them.
+        }
+
+        # MessageBase.from_dict creates a Message instance
+        msg_from_dict = MessageBase.from_dict(mock_payload_with_widgets)
+        
+        self.assertIsNotNone(msg_from_dict.custom_widgets, 
+                             "custom_widgets should be populated from_dict")
+        self.assertEqual(msg_from_dict.custom_widgets.get("model_select"), "claude-2")
+        self.assertEqual(msg_from_dict.custom_widgets.get("temperature"), 0.7)
+
+        metadata_without_widgets = {"source": "from_dict_test_no_widgets"}
+        mock_payload_no_widgets = {
+            "id": "test_msg_id_2",
+            "threadId": "test_thread_id_2",
+            "createdAt": "2023-01-01T12:01:00Z",
+            "output": "Another test message",
+            "name": "TestAuthor2",
+            "type": "assistant_message",
+            "metadata": metadata_without_widgets
+        }
+        msg_from_dict_no_widgets = MessageBase.from_dict(mock_payload_no_widgets)
+        self.assertIsNone(msg_from_dict_no_widgets.custom_widgets,
+                          "custom_widgets should be None from_dict when not in metadata")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/src/components/chat/MessageComposer/MessageComposer.test.tsx
+++ b/frontend/src/components/chat/MessageComposer/MessageComposer.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { RecoilRoot, useRecoilValue, useSetRecoilState } from 'recoil';
+import MessageComposer from './index'; // Adjust path as necessary
+import {
+  customWidgetDefinitionsState,
+  customWidgetValuesState,
+  IAttachment,
+  attachmentsState,
+  persistentCommandState
+} from '@/state/chat'; // Adjust path
+import { ICustomWidgetElement, IDropdownWidgetProps } from '@/types/widgets'; // Adjust path
+import { useChatData, useChatInteract, useAuth } from '@chainlit/react-client';
+import { TFunction } from 'i18next';
+
+// Mock @chainlit/react-client hooks
+vi.mock('@chainlit/react-client', async (importOriginal) => {
+    const actual = await importOriginal() as any;
+    return {
+        ...actual,
+        useChatData: vi.fn(),
+        useChatInteract: vi.fn(),
+        useAuth: vi.fn(),
+    };
+});
+
+// Mock child components that are not the focus of this test
+vi.mock('./Attachments', () => ({ Attachments: () => <div data-testid="attachments-mock" /> }));
+vi.mock('./CommandButtons', () => ({ default: () => <div data-testid="commandbuttons-mock" /> }));
+vi.mock('./CommandPopoverButton', () => ({ default: () => <div data-testid="commandpopoverbutton-mock" /> }));
+vi.mock('./Input', () => ({ default: vi.forwardRef((props, ref) => <textarea data-testid="input-mock" {...props} ref={ref as any} />) }));
+vi.mock('./Mcp', () => ({ default: () => <div data-testid="mcpbutton-mock" /> }));
+vi.mock('./SubmitButton', () => ({ default: () => <button data-testid="submitbutton-mock">Submit</button> }));
+vi.mock('./UploadButton', () => ({ default: () => <div data-testid="uploadbutton-mock" /> }));
+vi.mock('./VoiceButton', () => ({ default: () => <div data-testid="voicebutton-mock" /> }));
+vi.mock('@/components/widgets/CustomWidgetRenderer', () => ({
+    default: ({ element, value, onChange }: any) => (
+        <div data-testid={`custom-widget-${element.props.id}`}>
+            <span>Value: {value}</span>
+            <button onClick={() => onChange(element.props.id, 'new-' + value)}>
+                Change {element.props.label}
+            </button>
+        </div>
+    )
+}));
+
+
+// Mock i18n
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: ((key: string) => key) as TFunction,
+  }),
+}));
+
+
+const mockUser = { id: 'user1', identifier: 'test-user' };
+const mockSendMessage = vi.fn();
+const mockReplyMessage = vi.fn();
+
+const initialMockElements: ICustomWidgetElement[] = [
+  {
+    id: 'element-uuid-dropdown',
+    type: 'custom',
+    name: 'model_select_dropdown_element',
+    display: 'inline',
+    forId: 'COMPOSER_WIDGET',
+    props: {
+      widgetType: 'dropdown',
+      label: 'Select Model',
+      id: 'model_dropdown_widget_test',
+      options: [{ value: 'gpt-4', label: 'GPT-4' }, { value: 'claude-2', label: 'Claude 2' }],
+      initialValue: 'gpt-4',
+    } as IDropdownWidgetProps,
+  }
+];
+
+// Helper component to render MessageComposer and expose Recoil states for testing
+const TestBed = ({ initialElements = initialMockElements }: { initialElements?: ICustomWidgetElement[] }) => {
+  // Setup mock return values for hooks
+  (useChatData as Mock).mockReturnValue({
+    elements: initialElements,
+    askUser: null,
+    chatSettingsInputs: [],
+    disabled: false,
+  });
+  (useChatInteract as Mock).mockReturnValue({
+    sendMessage: mockSendMessage,
+    replyMessage: mockReplyMessage,
+  });
+  (useAuth as Mock).mockReturnValue({ user: mockUser, isAuthenticated: true, isReady: true });
+
+  const definitions = useRecoilValue(customWidgetDefinitionsState);
+  const values = useRecoilValue(customWidgetValuesState);
+  const setAttachments = useSetRecoilState(attachmentsState);
+  const setPersistentCommand = useSetRecoilState(persistentCommandState);
+
+  useEffect(() => {
+    // Initialize other states if MessageComposer depends on them for rendering
+    setAttachments([]);
+    setPersistentCommand(undefined);
+  }, [setAttachments, setPersistentCommand]);
+
+
+  return (
+    <div>
+      <MessageComposer
+        fileSpec={{ accept: ['*/*'], max_size_mb: 20, max_files: 1 }}
+        onFileUpload={() => {}}
+        onFileUploadError={() => {}}
+        autoScrollRef={{ current: false }}
+      />
+      <div data-testid="definitions-output">{JSON.stringify(definitions)}</div>
+      <div data-testid="values-output">{JSON.stringify(values)}</div>
+    </div>
+  );
+};
+
+
+describe('MessageComposer - Recoil State Logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset Recoil states for each test if necessary, though RecoilRoot should isolate
+  });
+
+  it('populates customWidgetDefinitionsState from useChatData elements', () => {
+    render(
+      <RecoilRoot>
+        <TestBed />
+      </RecoilRoot>
+    );
+    const definitionsOutput = screen.getByTestId('definitions-output');
+    const parsedDefinitions = JSON.parse(definitionsOutput.textContent || '[]');
+    expect(parsedDefinitions).toEqual(initialMockElements);
+  });
+
+  it('initializes customWidgetValuesState with initialValue from definitions', () => {
+    render(
+      <RecoilRoot>
+        <TestBed />
+      </RecoilRoot>
+    );
+    const valuesOutput = screen.getByTestId('values-output');
+    const parsedValues = JSON.parse(valuesOutput.textContent || '{}');
+    
+    const expectedInitialValue = initialMockElements[0].props.initialValue;
+    const widgetHtmlId = initialMockElements[0].props.id;
+    expect(parsedValues[widgetHtmlId]).toBe(expectedInitialValue);
+  });
+
+  it('updates customWidgetValuesState when handleWidgetChange is triggered via CustomWidgetRenderer', async () => {
+    render(
+      <RecoilRoot>
+        <TestBed />
+      </RecoilRoot>
+    );
+
+    const widgetHtmlId = initialMockElements[0].props.id;
+    const widgetInitialValue = initialMockElements[0].props.initialValue;
+
+    // Check initial value first
+    let valuesOutput = screen.getByTestId('values-output');
+    let parsedValues = JSON.parse(valuesOutput.textContent || '{}');
+    expect(parsedValues[widgetHtmlId]).toBe(widgetInitialValue);
+
+    // Find the button for the mocked widget and click it to trigger onChange
+    const changeButton = screen.getByRole('button', { name: `Change ${initialMockElements[0].props.label}` });
+    
+    await act(async () => {
+      fireEvent.click(changeButton);
+    });
+
+    // Check updated value
+    valuesOutput = screen.getByTestId('values-output'); // Re-query after update
+    parsedValues = JSON.parse(valuesOutput.textContent || '{}');
+    expect(parsedValues[widgetHtmlId]).toBe(`new-${widgetInitialValue}`);
+  });
+
+  it('does not initialize value if initialValue is undefined', () => {
+     const elementsWithoutInitialValue: ICustomWidgetElement[] = [
+      {
+        ...initialMockElements[0],
+        props: {
+          ...initialMockElements[0].props,
+          initialValue: undefined,
+        } as IDropdownWidgetProps,
+      }
+    ];
+    render(
+      <RecoilRoot>
+        <TestBed initialElements={elementsWithoutInitialValue} />
+      </RecoilRoot>
+    );
+    const valuesOutput = screen.getByTestId('values-output');
+    const parsedValues = JSON.parse(valuesOutput.textContent || '{}');
+    const widgetHtmlId = elementsWithoutInitialValue[0].props.id;
+    expect(parsedValues.hasOwnProperty(widgetHtmlId)).toBe(false); // Value should not be set
+  });
+
+  it('filters out elements not meant for COMPOSER_WIDGET or without widgetType', () => {
+    const mixedElements: ICustomWidgetElement[] = [
+      ...initialMockElements, // Valid composer widget
+      {
+        id: 'element-uuid-not-composer', type: 'custom', name: 'some_other_element',
+        display: 'inline', forId: 'NOT_COMPOSER', // Different forId
+        props: { widgetType: 'dropdown', id: 'other_id' } as any,
+      },
+      {
+        id: 'element-uuid-no-widgetType', type: 'custom', name: 'no_widget_type_element',
+        display: 'inline', forId: 'COMPOSER_WIDGET',
+        props: { id: 'another_id' } as any, // Missing widgetType
+      }
+    ];
+     render(
+      <RecoilRoot>
+        <TestBed initialElements={mixedElements} />
+      </RecoilRoot>
+    );
+    const definitionsOutput = screen.getByTestId('definitions-output');
+    const parsedDefinitions = JSON.parse(definitionsOutput.textContent || '[]');
+    expect(parsedDefinitions).toEqual([initialMockElements[0]]); // Only the valid composer widget
+  });
+
+});

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -1,15 +1,19 @@
-import { MutableRefObject, useCallback, useRef, useState } from 'react';
+import React, { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react'; // Added React and useEffect
 import { useTranslation } from 'react-i18next';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil'; // Added useRecoilValue
 import { v4 as uuidv4 } from 'uuid';
 
 import {
   FileSpec,
+  FileSpec,
   IStep,
   useAuth,
   useChatData,
-  useChatInteract
+  useChatInteract,
+  IElement // Assuming IElement is the base type for elements from useChatData
 } from '@chainlit/react-client';
+import { ICustomWidgetElement, CustomWidgetProps } from '@/types/widgets'; // Import custom widget types
+import CustomWidgetRenderer from '@/components/widgets/CustomWidgetRenderer'; // Import the renderer
 
 import { Settings } from '@/components/icons/Settings';
 import { Button } from '@/components/ui/button';
@@ -18,8 +22,10 @@ import { chatSettingsOpenState } from '@/state/project';
 import {
   IAttachment,
   attachmentsState,
-  persistentCommandState
-} from 'state/chat';
+  persistentCommandState,
+  customWidgetDefinitionsState, // Import custom widget states
+  customWidgetValuesState
+} from '@/state/chat';
 
 import { Attachments } from './Attachments';
 import CommandButtons from './CommandButtons';
@@ -54,9 +60,47 @@ export default function MessageComposer({
 
   const { user } = useAuth();
   const { sendMessage, replyMessage } = useChatInteract();
-  const { askUser, chatSettingsInputs, disabled: _disabled } = useChatData();
+  const { elements, askUser, chatSettingsInputs, disabled: _disabled } = useChatData(); // Added elements
+  const [widgetDefs, setWidgetDefs] = useRecoilState(customWidgetDefinitionsState);
+  const [widgetValues, setWidgetValues] = useRecoilState(customWidgetValuesState); // Renamed for clarity
 
   const disabled = _disabled || !!attachments.find((a) => !a.uploaded);
+
+  useEffect(() => {
+    // Filter for custom elements intended for the composer
+    const composerWidgets = elements.filter(
+      (el): el is ICustomWidgetElement => // Type guard
+        el.type === 'custom' &&
+        el.forId === 'COMPOSER_WIDGET' &&
+        // Ensure props is an object and has widgetType, which implies it's one of our custom widgets
+        typeof el.props === 'object' && el.props !== null && 'widgetType' in el.props
+    ) as ICustomWidgetElement[]; // Cast to our specific type
+
+    setWidgetDefs(composerWidgets);
+
+    // Initialize values if not already set
+    setWidgetValues(prevValues => {
+      const newValues = { ...prevValues };
+      composerWidgets.forEach(widgetDef => {
+        const props = widgetDef.props as CustomWidgetProps; // Cast to CustomWidgetProps
+        if (props.id && !(props.id in newValues) && props.initialValue !== undefined) {
+          newValues[props.id] = props.initialValue;
+        }
+      });
+      return newValues;
+    });
+  }, [elements, setWidgetDefs, setWidgetValues]);
+
+  const currentWidgetValues = useRecoilValue(customWidgetValuesState);
+
+  const handleWidgetChange = (widgetId: string, newValue: any) => {
+    setWidgetValues(prev => ({
+      ...prev,
+      [widgetId]: newValue
+    }));
+    // If real-time backend update is needed, this is where it would be triggered.
+    // For now, we just update local Recoil state.
+  };
 
   const onPaste = useCallback((event: ClipboardEvent) => {
     if (event.clipboardData && event.clipboardData.items) {
@@ -88,8 +132,14 @@ export default function MessageComposer({
         type: 'user_message',
         output: msg,
         createdAt: new Date().toISOString(),
-        metadata: { location: window.location.href }
+        metadata: { location: window.location.href } // Base metadata, always an object
       };
+
+      // Add custom widget values to message.metadata
+      // metadata is already guaranteed to be an object here.
+      if (Object.keys(currentWidgetValues).length > 0) {
+        message.metadata.custom_widgets = { ...currentWidgetValues };
+      }
 
       const fileReferences = attachments
         ?.filter((a) => !!a.serverId)
@@ -100,7 +150,7 @@ export default function MessageComposer({
       }
       sendMessage(message, fileReferences);
     },
-    [user, sendMessage]
+    [user, sendMessage, currentWidgetValues] // Added currentWidgetValues
   );
 
   const onReply = useCallback(
@@ -112,15 +162,21 @@ export default function MessageComposer({
         type: 'user_message',
         output: msg,
         createdAt: new Date().toISOString(),
-        metadata: { location: window.location.href }
+        metadata: { location: window.location.href } // Base metadata, always an object
       };
+
+      // Add custom widget values to message.metadata
+      // metadata is already guaranteed to be an object here.
+      if (Object.keys(currentWidgetValues).length > 0) {
+        message.metadata.custom_widgets = { ...currentWidgetValues };
+      }
 
       replyMessage(message);
       if (autoScrollRef) {
         autoScrollRef.current = true;
       }
     },
-    [user, replyMessage]
+    [user, replyMessage, currentWidgetValues] // Added currentWidgetValues
   );
 
   const submit = useCallback(() => {
@@ -167,7 +223,18 @@ export default function MessageComposer({
         placeholder={t('chat.input.placeholder')}
       />
       <div className="flex items-center justify-between">
-        <div className="flex items-center -ml-1.5">
+        {/* Custom Input Widgets Area */}
+        <div className="flex items-center flex-wrap gap-1 py-1"> {/* Added py-1 for some spacing */}
+          {widgetDefs.map(widgetDef => (
+            <CustomWidgetRenderer
+              key={widgetDef.props.id} // Use props.id from widget config
+              element={widgetDef}
+              value={currentWidgetValues[widgetDef.props.id]}
+              onChange={handleWidgetChange}
+            />
+          ))}
+        </div>
+        <div className="flex items-center -ml-1.5"> {/* This div now contains only the buttons */}
           <UploadButton
             disabled={disabled}
             fileSpec={fileSpec}
@@ -178,6 +245,7 @@ export default function MessageComposer({
             disabled={disabled}
             onCommandSelect={setSelectedCommand}
           />
+          {/* Removed the custom widgets from here as they are moved above */}
           {chatSettingsInputs.length > 0 && (
             <Button
               id="chat-settings-open-modal"
@@ -198,7 +266,7 @@ export default function MessageComposer({
             onCommandSelect={setSelectedCommand}
           />
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1"> {/* Submit button remains at the far right */}
           <SubmitButton
             onSubmit={submit}
             disabled={disabled || !value.trim()}

--- a/frontend/src/components/widgets/CustomWidgetRenderer.test.tsx
+++ b/frontend/src/components/widgets/CustomWidgetRenderer.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CustomWidgetRenderer from './CustomWidgetRenderer'; // Adjust path as necessary
+import { ICustomWidgetElement, IDropdownWidgetProps } from '@/types/widgets'; // Adjust path
+
+// Mock specific widget components that CustomWidgetRenderer might render
+vi.mock('./DropdownWidget', () => ({
+  // Default export: the DropdownWidget component
+  default: vi.fn(({ widget, value, onChange }) => (
+    <div data-testid="dropdown-widget-mock">
+      <span data-testid="dropdown-widget-id-prop">{widget.id}</span>
+      <span data-testid="dropdown-widget-value-prop">{value}</span>
+      <button onClick={() => onChange('new-value-from-dropdown')}>Change</button>
+    </div>
+  ))
+}));
+
+// Mock for another potential widget type for future-proofing tests
+// vi.mock('./TextInputWidget', () => ({
+//   default: vi.fn(({ widget, value, onChange }) => (
+//     <div data-testid="textinput-widget-mock">
+//       <span>{widget.label}</span>
+//       <input type="text" value={value} onChange={(e) => onChange(e.target.value)} />
+//     </div>
+//   ))
+// }));
+
+const mockDropdownElement: ICustomWidgetElement = {
+  id: 'element-uuid-1', // Main element ID
+  type: 'custom',
+  name: 'model_selection_dropdown_element',
+  display: 'inline',
+  forId: 'COMPOSER_WIDGET',
+  props: {
+    widgetType: 'dropdown',
+    label: 'Select Model',
+    id: 'model_dropdown_widget', // HTML ID for the widget itself
+    options: [{ value: 'gpt-4', label: 'GPT-4' }],
+    initialValue: 'gpt-4',
+  } as IDropdownWidgetProps,
+};
+
+// Example for a different widget type, if it existed
+// const mockTextInputElement: ICustomWidgetElement = {
+//   id: 'element-uuid-2',
+//   type: 'custom',
+//   name: 'user_name_input_element',
+//   display: 'inline',
+//   forId: 'COMPOSER_WIDGET',
+//   props: {
+//     widgetType: 'textinput', // Assuming a text input type
+//     label: 'Enter Name',
+//     id: 'name_text_input_widget',
+//     initialValue: 'Test User',
+//   } // as ITextInputWidgetProps, (if defined)
+// };
+
+describe('CustomWidgetRenderer', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks(); // Clear mock call counts before each test
+  });
+
+  it('renders DropdownWidget for widgetType "dropdown"', () => {
+    render(
+      <CustomWidgetRenderer
+        element={mockDropdownElement}
+        value="gpt-4"
+        onChange={mockOnChange}
+      />
+    );
+
+    const dropdownMock = screen.getByTestId('dropdown-widget-mock');
+    expect(dropdownMock).toBeInTheDocument();
+
+    // Verify props passed to the mocked DropdownWidget
+    // Access the mocked component itself to check its props
+    const DropdownWidgetMock = await vi.importActual('./DropdownWidget').then(mod => mod.default) as any;
+
+    expect(DropdownWidgetMock).toHaveBeenCalledTimes(1);
+    const callArgs = DropdownWidgetMock.mock.calls[0][0];
+    expect(callArgs.widget).toEqual(mockDropdownElement.props); // Check if the 'widget' prop (which is element.props) is correct
+    expect(callArgs.value).toBe('gpt-4'); // Check if the 'value' prop is correct
+    expect(callArgs.onChange).toBeInstanceOf(Function); // Check if 'onChange' is a function
+
+    // Simulate the onChange call from the mocked DropdownWidget
+    const changeButton = screen.getByRole('button', { name: 'Change' });
+    fireEvent.click(changeButton);
+    expect(mockOnChange).toHaveBeenCalledWith(mockDropdownElement.props.id, 'new-value-from-dropdown');
+  });
+
+  it('renders nothing and warns for unknown widgetType', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); // Suppress console.warn output
+
+    const unknownWidgetElement: ICustomWidgetElement = {
+      ...mockDropdownElement,
+      props: {
+        ...mockDropdownElement.props,
+        widgetType: 'unknownwidget' as any, // Force an unknown type
+      },
+    };
+
+    const { container } = render(
+      <CustomWidgetRenderer
+        element={unknownWidgetElement}
+        value="test"
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(container.firstChild).toBeNull(); // Should render nothing
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Unknown widget type:', 'unknownwidget');
+    
+    consoleWarnSpy.mockRestore();
+  });
+
+  // Add more tests if other widget types are implemented
+  // it('renders TextInputWidget for widgetType "textinput"', () => {
+  //   render(
+  //     <CustomWidgetRenderer
+  //       element={mockTextInputElement}
+  //       value="Test User"
+  //       onChange={mockOnChange}
+  //     />
+  //   );
+  //   expect(screen.getByTestId('textinput-widget-mock')).toBeInTheDocument();
+  //   // ... further assertions for TextInputWidget props
+  // });
+});

--- a/frontend/src/components/widgets/CustomWidgetRenderer.tsx
+++ b/frontend/src/components/widgets/CustomWidgetRenderer.tsx
@@ -1,0 +1,35 @@
+// frontend/src/components/widgets/CustomWidgetRenderer.tsx
+import React from 'react';
+import { ICustomWidgetElement, CustomWidgetProps } from '@/types/widgets'; // Adjust import path
+import DropdownWidget from './DropdownWidget';
+// Import other specific widget components here as they are created
+
+interface CustomWidgetRendererProps {
+  element: ICustomWidgetElement; // The full element data
+  value?: string | number | boolean | string[]; // Current value for this widget
+  onChange: (widgetId: string, value: any) => void; // Callback to update value in MessageComposer
+}
+
+const CustomWidgetRenderer: React.FC<CustomWidgetRendererProps> = ({ element, value, onChange }) => {
+  const widgetProps = element.props;
+
+  // Determine which specific widget component to render based on widgetProps.widgetType
+  switch (widgetProps.widgetType) {
+    case 'dropdown':
+      return (
+        <DropdownWidget
+          widget={widgetProps}
+          value={value as string | undefined} // Cast value appropriately
+          onChange={(newValue) => onChange(widgetProps.id, newValue)}
+        />
+      );
+    // Add cases for other widget types here
+    // case 'textinput':
+    //   return <TextInputWidget ... />;
+    default:
+      console.warn('Unknown widget type:', widgetProps.widgetType);
+      return null; // Or some fallback UI
+  }
+};
+
+export default CustomWidgetRenderer;

--- a/frontend/src/components/widgets/DropdownWidget.test.tsx
+++ b/frontend/src/components/widgets/DropdownWidget.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import DropdownWidget from './DropdownWidget'; // Adjust path as necessary
+import { IDropdownWidgetProps } from '@/types/widgets'; // Adjust path as necessary
+
+// Mock ShadCN UI components used by DropdownWidget
+// Vitest automatically mocks CSS module imports, but actual components might need manual mocks
+// if they cause issues in the JSDOM environment or are complex.
+// For basic rendering tests, often direct imports work if components are simple enough.
+// If using Radix primitives directly, they might need specific test setups.
+
+// Mock Label and Select components
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  )
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, value, onValueChange }: { children: React.ReactNode, value?: string, onValueChange?: (value: string) => void }) => (
+    <select data-testid="select-trigger" value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children, id }: { children: React.ReactNode, id: string }) => <div data-testid={id}>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span data-testid="select-value">{placeholder}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option data-testid={`select-item-${value}`} value={value}>{children}</option>
+  )
+}));
+
+
+const mockDropdownWidgetProps: IDropdownWidgetProps = {
+  widgetType: 'dropdown',
+  label: 'Test Model',
+  options: [
+    { value: 'gpt-3.5', label: 'GPT-3.5' },
+    { value: 'gpt-4', label: 'GPT-4' },
+  ],
+  initialValue: 'gpt-3.5',
+  id: 'test-model-dropdown',
+};
+
+describe('DropdownWidget', () => {
+  it('renders correctly with given props', () => {
+    const handleChange = vi.fn();
+    render(
+      <DropdownWidget
+        widget={mockDropdownWidgetProps}
+        value={mockDropdownWidgetProps.initialValue}
+        onChange={handleChange}
+      />
+    );
+
+    // Check if the label is rendered
+    expect(screen.getByText('Test Model')).toBeInTheDocument();
+
+    // Check if the SelectTrigger (mocked as a div with test-id) is rendered
+    // It contains the SelectValue, so we can check for its placeholder or initial value text
+    const trigger = screen.getByTestId('test-model-dropdown');
+    expect(trigger).toBeInTheDocument();
+    
+    // Check if the SelectValue (mocked as a span) displays the correct initial value or placeholder
+    // Our mock for SelectValue uses its placeholder prop as its content.
+    // The DropdownWidget passes widget.label or 'Select an option' to placeholder.
+    // Let's check for the label as placeholder.
+    expect(screen.getByTestId('select-value')).toHaveTextContent('Test Model');
+
+
+    // To check options, we would typically need to "open" the dropdown.
+    // In this mocked setup, SelectItems are rendered as <option> directly inside <select>.
+    // So we can query for them directly.
+    expect(screen.getByTestId('select-item-gpt-3.5')).toBeInTheDocument();
+    expect(screen.getByTestId('select-item-gpt-3.5')).toHaveTextContent('GPT-3.5');
+    expect(screen.getByTestId('select-item-gpt-4')).toBeInTheDocument();
+    expect(screen.getByTestId('select-item-gpt-4')).toHaveTextContent('GPT-4');
+  });
+
+  it('calls onChange with the correct value when an option is selected', () => {
+    const handleChange = vi.fn();
+    render(
+      <DropdownWidget
+        widget={mockDropdownWidgetProps}
+        value={mockDropdownWidgetProps.initialValue}
+        onChange={handleChange}
+      />
+    );
+
+    const selectTrigger = screen.getByTestId('select-trigger'); // Our mock Select is a <select>
+
+    // Simulate changing the value of the select element
+    fireEvent.change(selectTrigger, { target: { value: 'gpt-4' } });
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith('gpt-4');
+  });
+
+  it('renders with initialValue if provided and no current value', () => {
+    const handleChange = vi.fn();
+    render(
+      <DropdownWidget
+        widget={mockDropdownWidgetProps}
+        // value is undefined, so initialValue should be used
+        onChange={handleChange}
+      />
+    );
+    const selectTrigger = screen.getByTestId('select-trigger') as HTMLSelectElement;
+    expect(selectTrigger.value).toBe(mockDropdownWidgetProps.initialValue);
+  });
+
+  it('renders with current value even if initialValue is different', () => {
+    const handleChange = vi.fn();
+    render(
+      <DropdownWidget
+        widget={mockDropdownWidgetProps}
+        value="gpt-4" // current value overrides initialValue
+        onChange={handleChange}
+      />
+    );
+    const selectTrigger = screen.getByTestId('select-trigger') as HTMLSelectElement;
+    expect(selectTrigger.value).toBe('gpt-4');
+  });
+});

--- a/frontend/src/components/widgets/DropdownWidget.tsx
+++ b/frontend/src/components/widgets/DropdownWidget.tsx
@@ -1,0 +1,33 @@
+// frontend/src/components/widgets/DropdownWidget.tsx
+import React from 'react';
+import { IDropdownWidgetProps } from '@/types/widgets'; // Adjust import path if needed
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'; // Assuming these are ShadCN UI components
+import { Label } from '@/components/ui/label'; // Assuming ShadCN UI
+
+interface DropdownWidgetComponentProps {
+  widget: IDropdownWidgetProps;
+  value?: string;
+  onChange: (value: string) => void;
+}
+
+const DropdownWidget: React.FC<DropdownWidgetComponentProps> = ({ widget, value, onChange }) => {
+  return (
+    <div className="flex flex-col space-y-1.5" id={`container-${widget.id}`}>
+      {widget.label && <Label htmlFor={widget.id}>{widget.label}</Label>}
+      <Select value={value || widget.initialValue} onValueChange={onChange}>
+        <SelectTrigger id={widget.id}>
+          <SelectValue placeholder={widget.label || 'Select an option'} />
+        </SelectTrigger>
+        <SelectContent>
+          {widget.options.map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export default DropdownWidget;

--- a/frontend/src/state/chat.ts
+++ b/frontend/src/state/chat.ts
@@ -1,6 +1,7 @@
 import { atom } from 'recoil';
 
 import { ICommand } from 'client-types/*';
+import { ICustomWidgetElement } from 'types/widgets';
 
 export interface IAttachment {
   id: string;
@@ -22,4 +23,18 @@ export const attachmentsState = atom<IAttachment[]>({
 export const persistentCommandState = atom<ICommand | undefined>({
   key: 'PersistentCommand',
   default: undefined
+});
+
+export const customWidgetDefinitionsState = atom<ICustomWidgetElement[]>({
+  key: 'CustomWidgetDefinitions',
+  default: []
+});
+
+export interface IWidgetValues {
+  [widgetId: string]: string | number | boolean | string[] | undefined;
+}
+
+export const customWidgetValuesState = atom<IWidgetValues>({
+  key: 'CustomWidgetValues',
+  default: {}
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './Input';
 export * from './messageContext';
 export * from './NotificationCount';
+export * from './widgets';

--- a/frontend/src/types/widgets.ts
+++ b/frontend/src/types/widgets.ts
@@ -1,0 +1,36 @@
+export interface IDropdownOption {
+  value: string;
+  label: string;
+}
+
+export interface IDropdownWidgetProps {
+  widgetType: 'dropdown'; // Literal type
+  label: string;
+  options: IDropdownOption[];
+  initialValue?: string;
+  id: string; // HTML element ID
+}
+
+// Interface for the CustomElement props that will hold our widget data
+// We might need a more generic way if there are many widget types,
+// but for now, a union type can work.
+export type CustomWidgetProps = IDropdownWidgetProps; // Add other types like | ITextInputWidgetProps later
+
+// Interface for the CustomElement as received from backend, with typed props
+// This should align with what `CustomElement.to_dict()` produces plus our typed props.
+// Refer to `frontend/src/types/index.ts` for `IElement` or similar existing types.
+// We need to ensure the 'props' field of the incoming element data is correctly typed.
+export interface ICustomWidgetElement {
+   id: string; // This is the main element ID (UUID)
+   type: 'custom';
+   name: string;
+   display: 'inline' | 'side' | 'page'; // Adjust as per actual ElementDisplay type
+   forId?: string; // Should be "COMPOSER_WIDGET"
+   props: CustomWidgetProps;
+   // Add any other relevant fields from the base ElementDict/IElement type
+   // Based on IElement in frontend/src/types/index.ts:
+   language?: string;
+   url?: string; // If applicable for some custom elements
+   size?: 'small' | 'medium' | 'large'; // If applicable
+   isLoading?: boolean; // If custom widgets can have loading states
+}


### PR DESCRIPTION
This feature allows client applications to define and send custom input widgets (e.g., dropdowns) to be displayed in the MessageComposer, to the right of the attachment button.

Key changes include:

Backend:
- Added `custom_widgets.py` to define configurations for custom widgets (e.g., a sample 'Model Selection' dropdown).
- Modified `socket.py` to send these widget definitions (as `CustomElement` with `for_id='COMPOSER_WIDGET'`) to the frontend when a chat session starts.
- Updated `message.py`: The `MessageBase` class now has a `custom_widgets` attribute, automatically populated from message metadata, making these values easily accessible in the `on_message` callback.
- Added unit tests for custom widget configuration and `Message` class enhancements.

Frontend:
- Created `frontend/src/types/widgets.ts` for TypeScript interfaces related to custom widgets.
- Updated `frontend/src/state/chat.ts` with Recoil atoms (`customWidgetDefinitionsState`, `customWidgetValuesState`) to manage widget definitions and their current values.
- Implemented `DropdownWidget.tsx` and a generic `CustomWidgetRenderer.tsx` in `frontend/src/components/widgets/`.
- Modified `MessageComposer/index.tsx`:
  - Fetches elements from `useChatData` and populates `customWidgetDefinitionsState` with composer-specific widgets.
  - Initializes and updates `customWidgetValuesState` based on widget interactions.
  - Renders the custom widgets using `CustomWidgetRenderer`.
  - Includes selected widget values in the `metadata.custom_widgets` field of messages sent to the backend.
- Added unit tests for new widget components, renderer, and Recoil state logic within MessageComposer.
- Basic styling applied to ensure widgets are usable.

E2E test scenarios have also been outlined for comprehensive testing of this feature.